### PR TITLE
Support Rust & C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ paiza
 stash
 *.out
 
+tmp
+
 bigcase.txt

--- a/.vscode/cpp.code-snippets
+++ b/.vscode/cpp.code-snippets
@@ -1,0 +1,17 @@
+{
+    "Paiza template": {
+        "scope": "cpp",
+        "prefix": "paiza",
+        "body": [
+            "#include <iostream>",
+            "using namespace std;",
+            "",
+            "int main(void){",
+            "    string str;",
+            "    getline(cin, str);",
+            "    cout << \"XXXXXX\" << endl;",
+            "    return 0;",
+            "}",
+        ],
+    }
+}

--- a/.vscode/javascript.code-snippets
+++ b/.vscode/javascript.code-snippets
@@ -1,5 +1,5 @@
 {
-    "Paiza starting template": {
+    "Paiza template": {
         "scope": "javascript",
         "prefix": "paiza",
         "body": [

--- a/.vscode/python.code-snippets
+++ b/.vscode/python.code-snippets
@@ -1,5 +1,5 @@
 {
-    "Paiza starting template": {
+    "Paiza template": {
         "scope": "python",
         "prefix": "paiza",
         "body": [

--- a/.vscode/rust.code-snippets
+++ b/.vscode/rust.code-snippets
@@ -1,0 +1,11 @@
+{
+    "Paiza template": {
+        "scope": "rust",
+        "prefix": "paiza",
+        "body": [
+            "fn main() {",
+            "    println!(\"XXXXXX\");",
+            "}",
+        ],
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ Paiza や AtCoder などのオンラインジャッジのコーディングを�
 ```sh
 pip install fabric watchdog pyyaml
 ```
-- JavaScript でコーディングする場合、Node がインストールされている
+- JavaScript でコーディングする場合、Node.js がインストールされている
+- Rust でコーディングする場合、Rust がインストールされている
+- C++ でコーディングする場合、build-essential がインストールされている
+  - `sudo apt update && sudo apt install build-essential`
+
+現状ではコンテナ化など行っておらず、私用したい言語の処理系をローカル環境に直接インストールしておく必要があります。各言語のインストール方法は `WSL Ubuntu Node.js インストール` のようなキーワードで検索してみてください。
 
 ## 導入方法
 WSL 上の任意のディレクトリに移動し、このリポジトリを clone します

--- a/language/cpp.yml
+++ b/language/cpp.yml
@@ -1,0 +1,7 @@
+solver_file: "solve.cpp"
+solver_retry_file: "solve_retry.cpp"
+build_command: "cp {solver} {tmpdir} && cd {tmpdir} && g++ -std=gnu++20 -O2 -Wall -Wextra \
+-mtune=native -march=native \
+-fconstexpr-depth=2147483647 -fconstexpr-loop-limit=2147483647 -fconstexpr-ops-limit=2147483647 \
+ -o {solver.stem}.out {solver.name}"
+run_command: "cd {tmpdir} && ./{solver.stem}.out"

--- a/language/javascript.yml
+++ b/language/javascript.yml
@@ -1,3 +1,3 @@
 solver_file: "solve.js"
 solver_retry_file: "solve_retry.js"
-command: "node {solver}"
+run_command: "node {solver}"

--- a/language/pypy.yml
+++ b/language/pypy.yml
@@ -1,3 +1,3 @@
 solver_file: "solve.py"
 solver_retry_file: "solve_retry.py"
-command: "pypy {solver}"
+run_command: "pypy {solver}"

--- a/language/python.yml
+++ b/language/python.yml
@@ -1,3 +1,3 @@
 solver_file: "solve.py"
 solver_retry_file: "solve_retry.py"
-command: "python {solver}"
+run_command: "python {solver}"

--- a/language/rust.yml
+++ b/language/rust.yml
@@ -1,4 +1,6 @@
-# ちゃんと動作確認してません！
 solver_file: "solve.rs"
-solver_retry_file: "solve_retry.rs"
-command: "rustc {solver} -o {solver.stem}.out && ./{solver.stem}.out"
+extra_files: [
+  ["language/rust/Cargo.toml", "{tmpdir}/Cargo.toml"],
+]
+build_command: "cp {solver} {tmpdir} && cd {tmpdir} && cargo build --bin solve"
+run_command: "cd {tmpdir} && target/debug/solve"

--- a/language/rust/Cargo.toml
+++ b/language/rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "solver"
+edition = "2021"
+
+[[bin]]
+name="solve"
+path="solve.rs"
+
+[dependencies]
+regex = "=1"


### PR DESCRIPTION
Rust と C++ にざっくり対応。
テスト実行前にビルドを行い、テストのイテレーションでは生成されたバイナリを実行するようにした。
ビルドは一時フォルダ内で行い、ツール終了後はビルド成果物が残らないようになっている。