### PR TITLE
Copy Cargo.toml just befor build (Rust)

### DIFF
--- a/language/rust.yml
+++ b/language/rust.yml
@@ -1,6 +1,3 @@
 solver_file: "solve.rs"
-extra_files: [
-  ["language/rust/Cargo.toml", "{tmpdir}/Cargo.toml"],
-]
-build_command: "cp {solver} {tmpdir} && cd {tmpdir} && cargo build --bin solve"
+build_command: "cp language/rust/Cargo.toml {tmpdir} && cp {solver} {tmpdir} && cd {tmpdir} && cargo build --bin solve"
 run_command: "cd {tmpdir} && target/debug/solve"


### PR DESCRIPTION
Cargo.toml をビルド直前にテンプレートからコピーするよう修正

メモ: AtCoder で使えるクレート https://koma-koma.com/programming/rust-crate-2023/