### PR TITLE
Rust の対応を改善？

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 paiza
 stash
 *.out
+target
+Cargo.lock
+Cargo.toml
 
 tmp
 

--- a/language/rust.yml
+++ b/language/rust.yml
@@ -1,3 +1,4 @@
 solver_file: "solve.rs"
-build_command: "cp language/rust/Cargo.toml {tmpdir} && cp {solver} {tmpdir} && cd {tmpdir} && cargo build --bin solve"
-run_command: "cd {tmpdir} && target/debug/solve"
+hooks: "language/rust/hooks.py"
+build_command: "cd {workdir} && cargo build --bin solve"
+run_command: "cd {workdir} && target/debug/solve"

--- a/language/rust/Cargo.toml
+++ b/language/rust/Cargo.toml
@@ -8,3 +8,4 @@ path="solve.rs"
 
 [dependencies]
 regex = "=1"
+proconio = "0.4.5"

--- a/language/rust/hooks.py
+++ b/language/rust/hooks.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+import json
+
+SETTINGS_FILE = Path(".vscode/settings.json")
+
+
+def on_start(rootdir, workdir, tmpdir, solver_file, cases_file):
+    # テンプレートから作業ディレクトリに Cargo ファイルをコピー
+    cargo_path = Path(workdir, "Cargo.toml")
+    shutil.copy("language/rust/Cargo.toml", cargo_path)
+
+    if SETTINGS_FILE.exists():
+        with SETTINGS_FILE.open("r", encoding="utf-8") as f:
+            settings = json.load(f)
+
+        # VSCode が作業ディレクトリを Rust プロジェクトとして認識するよう
+        # settings.json に追加
+        linked_projects = settings.get("rust-analyzer.linkedProjects", [])
+        cargo_abs_path = str(cargo_path.resolve())
+        if cargo_abs_path not in linked_projects:
+            linked_projects.append(cargo_abs_path)
+        settings["rust-analyzer.linkedProjects"] = linked_projects
+
+        with SETTINGS_FILE.open("w", encoding="utf-8") as f:
+            json.dump(settings, f, indent=4)
+            f.write("\n")
+
+
+def on_exit(rootdir, workdir, tmpdir, solver_file, cases_file):
+    # Rust プロジェクト関連ファイルを削除
+    cargo_path = Path(workdir, "Cargo.toml")
+    cargo_lock_path = Path(workdir, "Cargo.lock")
+    target_path = Path(workdir, "target")
+    if cargo_path.exists():
+        cargo_path.unlink()
+    if cargo_lock_path.exists():
+        cargo_lock_path.unlink()
+    if target_path.exists():
+        shutil.rmtree(Path(workdir, "target"))
+
+    if SETTINGS_FILE.exists():
+        with SETTINGS_FILE.open("r", encoding="utf-8") as f:
+            settings = json.load(f)
+
+        # settings.json からプロジェクトパス（作業ディレクトリ）を削除
+        linked_projects = settings.get("rust-analyzer.linkedProjects", [])
+        cargo_abs_path = str(cargo_path.resolve())
+        if cargo_abs_path in linked_projects:
+            linked_projects = list(
+                filter(lambda x: x != cargo_abs_path, linked_projects)
+            )
+
+        if linked_projects:
+            settings["rust-analyzer.linkedProjects"] = linked_projects
+        else:
+            # 空になるならキーごと削除
+            del settings["rust-analyzer.linkedProjects"]
+
+        with SETTINGS_FILE.open("w", encoding="utf-8") as f:
+            json.dump(settings, f, indent=4)
+            f.write("\n")


### PR DESCRIPTION
VSCode はプロジェクトルートに Cargo.toml がないと rust-analyzer が動かず補完も何も効かなくなる。
対策としては https://zenn.dev/razokulover/scraps/17844b5b5c7147 があるが、このツールは問題ごとの作業ディレクトリを動的に作成するので `rust-analyzer.linkedProjects` をあらかじめ設定しておくことはできない。
そこで力業だが、ツールの開始時に settings.json の `rust-analyzer.linkedProjects` に作業ディレクトリを自動で書き込むことにした。終了時には削除する。

Rust で書く時の現状の動作は
- ツール開始時
  - 作業ディレクトリを作成し、language/rust/Cargo.toml をコピーしてくる
  - .vscode/settings.json の `rust-analyzer.linkedProjects` にコピーした Cargo.toml のパスを設定
- コードのビルドは作業ディレクトリで行う
- ツール終了時
  - 作業ディレクトリの Cargo.toml、他生成された Rust 関連のファイルを削除
  - .vscode/settings.json の `rust-analyzer.linkedProjects` から設定したパスを削除

クレートを追加したい場合、作業ディレクトリの Cargo.toml の dependencies に追記すればよいが、これはあとで消えるので、永続的な変更にしたいなら language/rust/Cargo.toml にも反映する必要がある。
もっとスマートなやり方ありそうだけどとりあえずこれで。

また、Rust で書いてみて入力処理が煩雑過ぎたので、language/rust/Cargo.toml に proconio を追加した（Paiza では使えないけど）
[[Rustで簡単標準入力]proconio使い方まとめ](https://qiita.com/Pikka2048/items/a0247e792aa4f8f6dd92)