### PR TITLE
Rust の対応を更新

### DIFF
--- a/language/rust/Cargo.toml
+++ b/language/rust/Cargo.toml
@@ -7,5 +7,7 @@ name="solve"
 path="solve.rs"
 
 [dependencies]
-regex = "=1"
-proconio = "0.4.5"
+regex = "=1.9.1"
+itertools = "=0.11.0"
+maplit = "=1.0.2"
+proconio = "=0.4.5"

--- a/language/rust/hooks.py
+++ b/language/rust/hooks.py
@@ -44,17 +44,8 @@ def on_exit(rootdir, workdir, tmpdir, solver_file, cases_file):
             settings = json.load(f)
 
         # settings.json からプロジェクトパス（作業ディレクトリ）を削除
-        linked_projects = settings.get("rust-analyzer.linkedProjects", [])
-        cargo_abs_path = str(cargo_path.resolve())
-        if cargo_abs_path in linked_projects:
-            linked_projects = list(
-                filter(lambda x: x != cargo_abs_path, linked_projects)
-            )
-
-        if linked_projects:
-            settings["rust-analyzer.linkedProjects"] = linked_projects
-        else:
-            # 空になるならキーごと削除
+        if "rust-analyzer.linkedProjects" in settings:
+            # キーごと削除する
             del settings["rust-analyzer.linkedProjects"]
 
         with SETTINGS_FILE.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
ツール終了時、.vscode/settings.json から rust-analyzer.linkedProjects を全て削除するようにした。
ツール起動したまま VSCode を落としたりすると残ってしまうため（作業フォルダの生成物は手動で消す必要あり）

いくつか Rust で問題を解いてみて、使ったクレートを language/rust/Cargo.toml に追加
いずれも AtCoder で使えるもの: https://img.atcoder.jp/file/language-update/language-list.html 